### PR TITLE
Update Nuget packages with Aspire GA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,3 +1,4 @@
+name: AspireShopWithSemanticKernel CI
 on:
   workflow_dispatch:
   push:

--- a/AspireShop.AppHost/AspireShop.AppHost.csproj
+++ b/AspireShop.AppHost/AspireShop.AppHost.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.6.24214.1" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.0-preview.6.24214.1" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.0-preview.6.24214.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.0.1" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.0.1" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AspireShop.BasketService/AspireShop.BasketService.csproj
+++ b/AspireShop.BasketService/AspireShop.BasketService.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.62.0" />
-    <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.62.0" />
-    <PackageReference Include="Aspire.StackExchange.Redis" Version="8.0.0-preview.6.24214.1" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.63.0" />
+    <PackageReference Include="Grpc.AspNetCore.HealthChecks" Version="2.63.0" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AspireShop.CatalogDb/AspireShop.CatalogDb.csproj
+++ b/AspireShop.CatalogDb/AspireShop.CatalogDb.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.6.24214.1" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/AspireShop.CatalogDbManager/AspireShop.CatalogDbManager.csproj
+++ b/AspireShop.CatalogDbManager/AspireShop.CatalogDbManager.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.6.24214.1" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/AspireShop.CatalogService/AspireShop.CatalogService.csproj
+++ b/AspireShop.CatalogService/AspireShop.CatalogService.csproj
@@ -13,8 +13,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.6.24214.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AspireShop.ChatService/AspireShop.ChatService.csproj
+++ b/AspireShop.ChatService/AspireShop.ChatService.csproj
@@ -8,12 +8,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.10.0" />
-      <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.10.0" />
+      <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.13.0" />
+      <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.13.0" />
       <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.10.0-alpha" />
-      <PackageReference Include="Microsoft.SemanticKernel.PromptTemplates.Handlebars" Version="1.10.0" />
-      <PackageReference Include="Microsoft.SemanticKernel.Yaml" Version="1.10.0" />
-      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
+      <PackageReference Include="Microsoft.SemanticKernel.PromptTemplates.Handlebars" Version="1.13.0" />
+      <PackageReference Include="Microsoft.SemanticKernel.Yaml" Version="1.13.0" />
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/AspireShop.Frontend/AspireShop.Frontend.csproj
+++ b/AspireShop.Frontend/AspireShop.Frontend.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.10.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Abstractions" Version="1.13.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.0.0-preview.6.24214.1" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.0.1" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.62.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.63.0">
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.63.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.64.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/AspireShop.ServiceDefaults/AspireShop.ServiceDefaults.csproj
+++ b/AspireShop.ServiceDefaults/AspireShop.ServiceDefaults.csproj
@@ -12,16 +12,16 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.6.24214.1" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="8.0.1" />
-    <PackageReference Include="Grpc.HealthCheck" Version="2.62.0" />
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.62.0" />
+    <PackageReference Include="Grpc.HealthCheck" Version="2.63.0" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.63.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Engineering updates:

- Aspire.Hosting.AppHost: 8.0.1
- Aspire.Hosting.PostgreSQL: 8.0.1
- Aspire.Hosting.Redis: 8.0.1
- Grpc.AspNetCore: 2.63.0
- Grpc.AspNetCore.HealthChecks: 2.63.0
- Aspire.StackExchange.Redis: 8.0.1
- Aspire.Npgsql.EntityFrameworkCore.PostgreSQL: 8.0.1
- Swashbuckle.AspNetCore: 6.6.2
- Microsoft.SemanticKernel.Abstractions: 1.13.0
- Microsoft.SemanticKernel.Connectors.OpenAI: 1.13.0
- Microsoft.SemanticKernel.PromptTemplates.Handlebars: 1.13.0
- Microsoft.SemanticKernel.Yaml: 1.13.0
- Microsoft.Extensions.ServiceDiscovery.Yarp: 8.0.1
- Grpc.Net.ClientFactory: 2.63.0
- Grpc.Tools: 2.64.0
- Microsoft.Extensions.ServiceDiscovery: 8.0.1
- OpenTelemetry.Instrumentation.Runtime: 1.8.1
- Grpc.HealthCheck: 2.63.0