### PR TITLE
Build step to setup dotnet

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,10 +22,15 @@ jobs:
     steps:
       - name: 🌱Checkout the branch
         uses: actions/checkout@v4
-
+        
+      - name: 📦Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.200
+            
       - name: ⚙️Install azd
         uses: Azure/setup-azd@v1.0.0
-
+        
       - name: 🦾Install .NET Aspire workload
         run: dotnet workload install aspire
         


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/build.yaml` file to add a step for installing the .NET SDK in the GitHub Actions workflow. This new step uses the `actions/setup-dotnet@v4` action with a specified .NET version of `8.0.200`. This will ensure that the correct version of .NET is installed and available for use in subsequent steps of the workflow.